### PR TITLE
Lombok @Data ist nicht ganz ungefährlich auf JPA Entities durch das M…

### DIFF
--- a/service/src/main/java/ch/no1hardy/service/model/team/Team.java
+++ b/service/src/main/java/ch/no1hardy/service/model/team/Team.java
@@ -6,35 +6,54 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Transient;
 import jakarta.validation.constraints.NotNull;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
 import java.util.ArrayList;
 import java.util.List;
 
-@Data
 @Entity
-@EqualsAndHashCode(callSuper = true)
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString(onlyExplicitlyIncluded = true)
 public class Team extends BaseEntity {
+
     @NotNull
+    @ToString.Include
     private String name;
 
     @NotNull
+    @ToString.Include
     private String shortName;
 
     @NotNull
     private String flag;
 
     @OneToMany(mappedBy = "teamHome")
-    @EqualsAndHashCode.Exclude
-    @ToString.Exclude
-    private List<Game> gamesHome = List.of();
+    private List<Game> gamesHome = new ArrayList<>();
 
     @OneToMany(mappedBy = "teamGuest")
-    @EqualsAndHashCode.Exclude
-    @ToString.Exclude
-    private List<Game> gamesGuest = List.of();
+    private List<Game> gamesGuest = new ArrayList<>();
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Team other)) {
+            return false;
+        }
+
+        return getId() != null && getId().equals(other.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
 
     @Transient
     public List<Game> getGames() {


### PR DESCRIPTION
Lombok @Data ist nicht ganz ungefährlich auf JPA Entities durch das Mitbringen von equals und hashCode. Das kann zu StackOverflows und Murks beim Vergleichen führen. Möglich ist auch, dass es automatisch zum n+1 Problem führt und ich glaube auch mich zu erinnern, mal was von LazyLoadingIssues gelesne zu haben.
Es gibt mehrere Lösungansätze: gar nichts tun, weil es kein Produktivcode ist. Oder eine eindeutige BusinessId nutzen (ist immer über die gesamte Lebenszeit gleich). Oder sicherstellen, dass hashCode über die gesamte Lebenszeit immer dasselbe zurückgibt.
Die Id so wie Du sie abhängig von super machst. Das kann später schiefgehen, glaubs hashCode kann sich wieder ändern...wenn ein Team erzeugt wird

Ich hab mal einen konkreten Vorschlag für Team gemacht. Ob man das jetzt für wm26 braucht... Für unseren AG aber schon.

BTW: Ids mit UUID ist bei unserem AG anscheinend beliebt, finde ich aber nicht gut. IDs sollten schon von der DB generiert werden....

@Data auf Superklassen ist auch Mist, da Du die Hälfte davon nicht brauchst. Nimm besser nur die Lombok-Annotation, die es wirklich braucht. Allgemein ist @Data schön bequem, führt aber zu Problemen, vor allem auf JPA Entities.


new ArrayList(): list.of() ist immutable; Hibernate will aber mit der Liste spielen, besser hier so.
