### PR TITLE
fix: remove artifact handoff and add docker registry login to CI workflows (#331)

### DIFF
--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -1,6 +1,6 @@
-name: build-and-store-docker-image
+name: build-docker-image
 author: no1ha
-description: build-and-store-docker-image
+description: build-docker-image
 inputs:
   project:
     description: 'The project name and folder of image that is built'
@@ -11,13 +11,3 @@ runs:
     - name: 'Build docker image'
       shell: bash
       run: docker build -t wm-2026-${{ inputs.project }} -f ${{ inputs.project }}/Dockerfile .
-    - name: 'Export docker image as tar'
-      shell: bash
-      run: docker save wm-2026-${{ inputs.project }} | gzip > image.tar.gz
-    - name: 'Upload docker image as artifact'
-      uses: actions/upload-artifact@v4
-      with:
-        retention-days: 1
-        path: image.tar.gz
-        name: 'wm-2026-${{ inputs.project }}-${{ github.sha }}'
-        overwrite: true

--- a/.github/actions/publish-docker-image/action.yml
+++ b/.github/actions/publish-docker-image/action.yml
@@ -5,9 +5,18 @@ inputs:
   project:
     description: 'The project of the image that is published'
     required: true
+  registry_username:
+    description: 'Docker registry username'
+    required: true
+  registry_password:
+    description: 'Docker registry password or token'
+    required: true
 runs:
   using: composite
   steps:
+    - name: 'Log in to Docker registry'
+      shell: bash
+      run: echo "${{ inputs.registry_password }}" | docker login docker.no1hardy.ch -u "${{ inputs.registry_username }}" --password-stdin
     - name: 'Get current date'
       shell: bash
       run: echo "NOW=$(date +'%y-%m-%d')" >> $GITHUB_ENV

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -10,7 +10,7 @@ jobs:
           sparse-checkout: |
             frontend
             gradle
-      - name: Install gradle gradle
+      - name: Install gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Grant execute permission to gradlew
         run: chmod +x ./gradlew
@@ -46,23 +46,10 @@ jobs:
         uses: ./.github/actions/build-docker-image
         with:
           project: 'frontend'
-  publish:
-    needs: [ build ]
-    runs-on: ubuntu-latest
-    if: github.ref_name == 'develop'
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: |
-            .github
-      - name: 'Download docker image artifact'
-        uses: actions/download-artifact@v4
-        with:
-          name: 'wm-2026-frontend-${{ github.sha }}'
-      - name: 'Load docker image'
-        run: gunzip -c image.tar.gz | docker load
       - name: 'Publish docker image'
+        if: github.ref_name == 'develop'
         uses: ./.github/actions/publish-docker-image
         with:
           project: 'frontend'
+          registry_username: ${{ secrets.DOCKER_REGISTRY_USER }}
+          registry_password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}

--- a/.github/workflows/proxy.yml
+++ b/.github/workflows/proxy.yml
@@ -15,23 +15,10 @@ jobs:
         uses: ./.github/actions/build-docker-image
         with:
           project: 'proxy'
-  publish:
-    needs: [ build ]
-    runs-on: ubuntu-latest
-    if: github.ref_name == 'develop'
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: |
-            .github
-      - name: 'Download docker image artifact'
-        uses: actions/download-artifact@v4
-        with:
-          name: 'wm-2026-proxy-${{ github.sha }}'
-      - name: 'Load docker image'
-        run: gunzip -c image.tar.gz | docker load
       - name: 'Publish docker image'
+        if: github.ref_name == 'develop'
         uses: ./.github/actions/publish-docker-image
         with:
           project: 'proxy'
+          registry_username: ${{ secrets.DOCKER_REGISTRY_USER }}
+          registry_password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -64,23 +64,10 @@ jobs:
         uses: ./.github/actions/build-docker-image
         with:
           project: 'service'
-  publish:
-    needs: [ build ]
-    if: github.ref_name == 'develop'
-    runs-on: ubuntu-latest
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: |
-            .github
-      - name: 'Download docker image artifact'
-        uses: actions/download-artifact@v4
-        with:
-          name: 'wm-2026-service-${{ github.sha }}'
-      - name: 'Load docker image'
-        run: gunzip -c image.tar.gz | docker load
       - name: 'Publish docker image'
+        if: github.ref_name == 'develop'
         uses: ./.github/actions/publish-docker-image
         with:
           project: 'service'
+          registry_username: ${{ secrets.DOCKER_REGISTRY_USER }}
+          registry_password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}


### PR DESCRIPTION
- Simplify build-docker-image action to just build (no tar/upload)
- Add docker login step to publish-docker-image action using DOCKER_REGISTRY_USER/TOKEN secrets
- Merge publish job into build job in all three workflows; publish step gated on develop branch
- Fix typo in frontend.yml lint job ("Install gradle gradle" → "Install gradle")

https://claude.ai/code/session_013CV1smyHY6xbkqQv2o5gRW